### PR TITLE
drmu_dmabuf: Correct check of dma heap names

### DIFF
--- a/drmu/drmu_dmabuf.c
+++ b/drmu/drmu_dmabuf.c
@@ -168,7 +168,7 @@ drmu_dmabuf_env_new_video(struct drmu_env_s * const du)
     };
     const char * const * pfname;
 
-    for (pfname = names; pfname != NULL; ++pfname) {
+    for (pfname = names; *pfname != NULL; ++pfname) {
         const int fd = open(*pfname, O_RDWR | O_CLOEXEC);
         drmu_dmabuf_env_t * const dde = drmu_dmabuf_env_new_fd(du, fd);
         if (dde != NULL)


### PR DESCRIPTION
Check the contents of the array, not the pointer to it.

For some reason the permissions on my heaps got messed up, and I was getting a seg fault due to this. When fixed we get a clean failure.